### PR TITLE
natures system addictions and Nicknames system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+src/cotire/
+data/world/global_dash.otbm

--- a/data/actions/scripts/poke/catch.lua
+++ b/data/actions/scripts/poke/catch.lua
@@ -83,6 +83,7 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	-- persist corpse skull (sex) and nature before removing corpse so they can be saved into the pokeball
 	local corpseSkull = targetCorpse:getSpecialAttribute("corpseSkull")
 	local corpseNature = targetCorpse:getSpecialAttribute("corpseNature")
+    local corpseNickname = targetCorpse:getSpecialAttribute("corpseNickname")
 	item:remove(1)
 	targetCorpse:remove()
 	if player:getStorageValue(storageTry) < 0 then
@@ -93,9 +94,9 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	if math.random(1, 300) <= chance then -- caught
 		-- check how many pokeballs the player has
 		if player:getSlotItem(CONST_SLOT_BACKPACK) and player:getSlotItem(CONST_SLOT_BACKPACK):getEmptySlots() >= 1 and player:getFreeCapacity() >= 1 then -- add to backpack
-			addEvent(doAddPokeball, delayMessage, player:getId(), name, level, initialBoost, ballKey, false, delayMessage, corpseSkull, corpseNature)
+			addEvent(doAddPokeball, delayMessage, player:getId(), name, level, initialBoost, ballKey, false, delayMessage, corpseSkull, corpseNature, corpseNickname)
 		else -- send to cp
-			local addPokeball = doAddPokeball(player:getId(), name, level, initialBoost, ballKey, true, delayMessage + 4000, corpseSkull, corpseNature)
+			local addPokeball = doAddPokeball(player:getId(), name, level, initialBoost, ballKey, true, delayMessage + 4000, corpseSkull, corpseNature, corpseNickname)
 			if not addPokeball then
 				print("ERROR! Player " .. player:getName() .. " lost pokemon " .. name .. "! addPokeball false")
 			end

--- a/data/creaturescripts/scripts/corpselevel.lua
+++ b/data/creaturescripts/scripts/corpselevel.lua
@@ -19,6 +19,20 @@ function onDeath(creature, corpse, killer, mostDamage, unjustified, mostDamage_u
 						corpse:setSpecialAttribute("corpseNature", nature)
 					end
 				end
+	                -- persist per-instance display name (nickname) if present
+					if creature.getNickname then
+						local nick = creature:getNickname()
+						if nick ~= nil and nick ~= "" then
+							-- sanitize nickname to avoid serialization issues
+							nick = tostring(nick)
+							-- remove control chars and quotes/backslashes
+							nick = nick:gsub('[%c\\\"]', '')
+							nick = nick:gsub('%s+', ' '):gsub('^%s*(.-)%s*$', '%1')
+							if nick ~= nil and nick ~= '' then
+								corpse:setSpecialAttribute("corpseNickname", nick)
+							end
+						end
+					end
 				print("[CorpseLevel] " .. creature:getName() .. " died with skull=" .. tostring(skull) .. (nature ~= nil and (", nature=" .. tostring(nature)) or ""))
 			end
 		else

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -118,6 +118,13 @@ function Player:onLook(thing, position, distance)
 					else
 						description = string.format("%s\nIt belongs to %s. Level: %s. Boost: +%s. Health: %s. Attack: %s. Magic Attack: %s. Magic Defense: %s. Armor: %s. Speed: %s.\n Love: %s.", description, master:getName(), pokeLevel, pokeBoost, th, taStr, tmaStr, tmdStr, tdStr, tsStr, pokeLove)
 					end
+
+					-- show nickname if summon has a display name different from base pokeName
+					local summonDisplay = thing:getName()
+					local baseName = item and item:getSpecialAttribute("pokeName") or nil
+					if summonDisplay and baseName and summonDisplay ~= baseName then
+						description = string.format("%s\nNickname: %s.", description, summonDisplay)
+					end
 				end
 			end
 		end
@@ -167,6 +174,11 @@ function Player:onLook(thing, position, distance)
 				else
 					description = string.format("%s\nIt contains a %s. Level: %s. Boost: +%s. %s", description, pokeName, pokeLevel, pokeBoost, healthStr)
 				end
+			end
+			-- append stored nickname if any (pokeball description may already include this via description special attribute)
+			local storedNick = thing:getSpecialAttribute("pokeNickname")
+			if storedNick and storedNick ~= "" then
+				description = string.format("%s\nNickname: %s.", description, storedNick)
 			end
 		end
 	end

--- a/data/lib/core/nature_behaviors.lua
+++ b/data/lib/core/nature_behaviors.lua
@@ -1,0 +1,231 @@
+-- Module: nature_behaviors.lua
+-- Prototype: map NATURE_* -> behavior table and apply to creatures via storage
+
+local M = {}
+
+-- NOTE: Player storage API exists, but Creature storage isn't exposed in this codebase.
+-- Use a Lua-side instance map keyed by creature id to avoid relying on Creature:setStorageValue/getStorageValue.
+local STORAGE_BASE = 200000
+M.STORAGE_KEYS = {
+  NATURE_ID = STORAGE_BASE + 0,
+  HOSTILE = STORAGE_BASE + 1,
+  PASSIVE = STORAGE_BASE + 2,
+  RUNONHEALTH = STORAGE_BASE + 3,
+  STATICATTACK = STORAGE_BASE + 4,
+  TARGETDIST = STORAGE_BASE + 5,
+  THINK_ACTIVE = STORAGE_BASE + 6,
+}
+
+-- instances[id] = profile table
+local instances = {}
+local activeThinkers = {}
+
+-- Behavior profiles taken from src/docs/NATURES_SYSTEM.MD
+-- Each entry: {hostile=0/1, passive=0/1, runonhealth=percent or 0, staticattack=ms or nil, targetdistance=int or nil}
+local behaviors = {}
+
+-- 1 Hardy (Neutro)
+behaviors[NATURE_HARDY] = {hostile=1, passive=1, runonhealth=20, staticattack=3000, targetdistance=1}
+-- 2 Lonely
+behaviors[NATURE_LONELY] = {hostile=1, passive=1, runonhealth=40, staticattack=2000, targetdistance=1}
+-- 3 Brave
+behaviors[NATURE_BRAVE] = {hostile=1, passive=0, runonhealth=0, staticattack=50000, targetdistance=1}
+-- 4 Adamant
+behaviors[NATURE_ADAMANT] = {hostile=1, passive=0, runonhealth=0, staticattack=1500, targetdistance=1}
+-- 5 Naughty
+behaviors[NATURE_NAUGHTY] = {hostile=1, passive=0, runonhealth=0, staticattack=800, targetdistance=2}
+-- 6 Bold
+behaviors[NATURE_BOLD] = {hostile=1, passive=1, runonhealth=30, staticattack=7000, targetdistance=1}
+-- 7 Docile
+behaviors[NATURE_DOCILE] = {hostile=1, passive=1, runonhealth=25, staticattack=4000, targetdistance=1}
+-- 8 Relaxed
+behaviors[NATURE_RELAXED] = {hostile=1, passive=1, runonhealth=15, staticattack=25000, targetdistance=1}
+-- 9 Impish
+behaviors[NATURE_IMPISH] = {hostile=1, passive=1, runonhealth=35, staticattack=3000, targetdistance=1}
+-- 10 Lax
+behaviors[NATURE_LAX] = {hostile=1, passive=1, runonhealth=50, staticattack=3500, targetdistance=1}
+-- 11 Modest
+behaviors[NATURE_MODEST] = {hostile=1, passive=1, runonhealth=30, staticattack=2500, targetdistance=5}
+-- 12 Mild
+behaviors[NATURE_MILD] = {hostile=1, passive=1, runonhealth=60, staticattack=2500, targetdistance=4}
+-- 13 Quiet
+behaviors[NATURE_QUIET] = {hostile=1, passive=0, runonhealth=0, staticattack=45000, targetdistance=5}
+-- 14 Rash
+behaviors[NATURE_RASH] = {hostile=1, passive=0, runonhealth=5, staticattack=1200, targetdistance=1}
+-- 15 Calm
+behaviors[NATURE_CALM] = {hostile=1, passive=1, runonhealth=40, staticattack=6000, targetdistance=1}
+-- 16 Gentle
+behaviors[NATURE_GENTLE] = {hostile=0, passive=1, runonhealth=80, staticattack=9000, targetdistance=1}
+-- 17 Sassy
+behaviors[NATURE_SASSY] = {hostile=1, passive=1, runonhealth=20, staticattack=8000, targetdistance=1}
+-- 18 Careful
+behaviors[NATURE_CAREFUL] = {hostile=1, passive=1, runonhealth=50, staticattack=12000, targetdistance=1}
+-- 19 Jolly
+behaviors[NATURE_JOLLY] = {hostile=0, passive=0, runonhealth=0, staticattack=500, targetdistance=2}
+-- 20 Hasty
+behaviors[NATURE_HASTY] = {hostile=1, passive=1, runonhealth=50, staticattack=200, targetdistance=1}
+-- 21 Timid
+behaviors[NATURE_TIMID] = {hostile=0, passive=1, runonhealth=100, staticattack=1000, targetdistance=1}
+-- 22 Naive
+behaviors[NATURE_NAIVE] = {hostile=1, passive=1, runonhealth=35, staticattack=900, targetdistance=1}
+-- 23 Serious
+behaviors[NATURE_SERIOUS] = {hostile=1, passive=1, runonhealth=20, staticattack=3000, targetdistance=1}
+-- 24 Bashful
+behaviors[NATURE_BASHFUL] = {hostile=1, passive=1, runonhealth=40, staticattack=4000, targetdistance=1}
+-- 25 Quirky (use a simple default for prototype)
+behaviors[NATURE_QUIRKY] = {hostile=1, passive=1, runonhealth=30, staticattack=3000, targetdistance=1}
+
+-- Helper: safely set storage if API exists
+-- no-op safeSetStorage kept for compatibility in case Creature storage is added later
+local function safeSetStorage(creature, key, value)
+  -- intentionally empty: we store per-creature info in the local `instances` table instead
+end
+
+-- Apply profile to creature via storage keys. Non-destructive: writes values even if present.
+function M.applyNatureBehavior(creature)
+  if not creature then return false end
+  local ok, nature = pcall(function() return creature:getNature() end)
+  if not ok or not nature then
+    return false
+  end
+
+  local profile = behaviors[nature]
+  if not profile then
+    profile = behaviors[NATURE_HARDY]
+  end
+
+  -- get creature id; if id isn't assigned yet (0), retry shortly
+  local cid = nil
+  pcall(function() cid = creature:getId() end)
+  cid = tonumber(cid) or 0
+  local name = nil
+  pcall(function() name = creature:getName() end)
+
+  if cid <= 0 then
+    -- schedule a retry after a short delay so engine can assign an id
+    addEvent(function()
+      pcall(function() M.applyNatureBehavior(creature) end)
+    end, 50)
+    return true
+  end
+
+  -- store profile in Lua map keyed by creature id
+  instances[cid] = {
+    nature = nature,
+    profile = profile,
+    name = name,
+    createdAt = os.time(),
+  }
+
+  print(string.format("[nature_behaviors] applied nature %s (%d) to %s id=%d", tostring(nature), tonumber(nature) or 0, tostring(name) or "<creature>", cid))
+
+  -- start periodic thinker for this instance if not already active
+  if not activeThinkers[cid] then
+    activeThinkers[cid] = true
+    pcall(function() startNatureThink(cid) end)
+  end
+
+  return true
+end
+
+
+-- Periodic thinker: reads storage and enforces behavior (fallback when Monster:onThink isn't fired)
+local THINK_INTERVAL = 2000
+function startNatureThink(id)
+  if not id then return end
+  local function thinkOnce(creatureId)
+    local c = Creature(creatureId)
+    if not c then return end
+    -- read profile from Lua instances map (fallback to defaults)
+    local inst = instances[creatureId]
+    local hostile = 1
+    local passive = 1
+    local runon = 0
+    local targdist = 1
+    if inst and inst.profile then
+      hostile = inst.profile.hostile or hostile
+      passive = inst.profile.passive or passive
+      runon = inst.profile.runonhealth or runon
+      targdist = inst.profile.targetdistance or targdist
+    end
+
+    -- debug
+    pcall(function()
+      print(string.format("[nature_think] id=%s name=%s hostile=%s passive=%s runon=%s targdist=%s", tostring(creatureId), tostring(c:getName()), tostring(hostile), tostring(passive), tostring(runon), tostring(targdist)))
+    end)
+
+    -- passive: remove targets
+    if hostile == 0 and passive == 1 then
+      pcall(function()
+        local tlist = c:getTargetList()
+        if tlist then
+          for i = 1, #tlist do
+            local t = tlist[i]
+            if t then
+              print(string.format("[nature_think] passive: removing target %s from %s", tostring(t:getName() or "?"), tostring(c:getName() or "?")))
+              c:removeTarget(t)
+            end
+          end
+        end
+      end)
+    end
+
+    -- runonhealth: flee (drop targets)
+    if runon and runon > 0 then
+      pcall(function()
+        local hp = c:getHealth()
+        local maxhp = c:getMaxHealth()
+        if hp and maxhp and maxhp > 0 then
+          local pct = (hp / maxhp) * 100
+          if pct <= runon then
+            local tlist = c:getTargetList()
+            if tlist then
+              for i = 1, #tlist do
+                local t = tlist[i]
+                if t then
+                  print(string.format("[nature_think] runon: %s (%.1f%% <= %d%%) removing %s", tostring(c:getName() or "?"), pct, runon, tostring(t:getName() or "?")))
+                  c:removeTarget(t)
+                end
+              end
+            end
+          end
+        end
+      end)
+    end
+
+    -- hostile: set first nearby player if none
+    if hostile == 1 and passive == 0 then
+      pcall(function()
+        local ct = c:getTarget()
+        if not ct then
+          local pos = c:getPosition()
+          local specs = Game.getSpectators(pos, true, true)
+          if specs then
+            for _, sp in ipairs(specs) do
+              if sp and sp:isPlayer() then
+                print(string.format("[nature_think] hostile: %s id=%s setting target -> %s", tostring(c:getName() or "?"), tostring(c:getId() or "?"), tostring(sp:getName() or "?")))
+                c:setTarget(sp)
+                break
+              end
+            end
+          end
+        end
+      end)
+    end
+
+    -- re-schedule if creature still exists
+    if Creature(creatureId) then
+      addEvent(function(id) startNatureThink(id) end, THINK_INTERVAL, creatureId)
+    end
+  end
+
+  -- schedule first call
+  addEvent(function(id) thinkOnce(id) end, THINK_INTERVAL, id)
+end
+
+-- Helper to expose profile read for other scripts
+function M.getProfile(nature)
+  return behaviors[nature]
+end
+
+return M

--- a/data/scripts/maintenance/sanitize_pokeballs.lua
+++ b/data/scripts/maintenance/sanitize_pokeballs.lua
@@ -1,0 +1,45 @@
+-- One-off maintenance script: sanitize pokeNickname special-attributes on all players' pokeballs
+-- Usage: load it from server console or call the function from an admin script.
+
+function sanitizeAllPokeballs()
+    local players = Game.getPlayers()
+    if not players or #players == 0 then
+        print("No players online to scan.")
+        return true
+    end
+
+    local total = 0
+    local fixed = 0
+
+    for i = 1, #players do
+        local pid = players[i]
+        local player = Player(pid)
+        if player then
+            local pokeballs = player:getPokeballs()
+            for j = 1, #pokeballs do
+                local ball = pokeballs[j]
+                if ball and ball:isPokeball() then
+                    total = total + 1
+                    local nick = ball:getSpecialAttribute("pokeNickname")
+                    if nick then
+                        local safe = sanitizeNickname(nick)
+                        if safe ~= nick then
+                            if safe and safe ~= "" then
+                                ball:setSpecialAttribute("pokeNickname", safe)
+                            else
+                                ball:setSpecialAttribute("pokeNickname", nil)
+                            end
+                            fixed = fixed + 1
+                            print("Fixed pokeball for player " .. player:getName() .. ": '" .. tostring(nick) .. "' -> '" .. tostring(safe) .. "'")
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    print("Sanitization complete. Scanned pokeballs: " .. total .. ", fixed: " .. fixed)
+    return true
+end
+
+return true

--- a/data/talkactions/scripts/give_nickname.lua
+++ b/data/talkactions/scripts/give_nickname.lua
@@ -1,0 +1,236 @@
+function onSay(player, words, param)
+    -- Usage: !givenickname <nickname>
+    if not player or not player:isPlayer() then
+        return false
+    end
+
+    local raw = param and param:trim() or ""
+    if raw == nil or raw == "" then
+        player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Usage: !givenickname <nickname> OR !givenickname <index> <nickname>")
+        return false
+    end
+
+    -- limit length to avoid abuse
+    if #raw > 40 then
+        player:sendCancelMessage("Nickname is too long. Max 40 characters.")
+        return false
+    end
+
+    -- get the player's active summon (if any)
+    local summon = player:getSummon()
+    local ball = nil
+    -- prefer the ball currently marked as being used
+    ball = player:getUsingBall()
+
+    -- Support explicit index: '!givenickname <index> <nickname>'
+    -- If player specified an index, select that pokeball directly and use the rest as nickname
+    local firstArg, restArg = raw:match("^(%S+)%s*(.-)$")
+    local idx = tonumber(firstArg)
+    if idx then
+        local pokeballs = player:getPokeballs() or {}
+        if #pokeballs == 0 then
+            player:sendCancelMessage("You have no pokeballs.")
+            return false
+        end
+        if idx < 1 or idx > #pokeballs then
+            player:sendCancelMessage("Invalid pokeball index. You have " .. #pokeballs .. " pokeballs.")
+            return false
+        end
+        ball = pokeballs[idx]
+        -- remainder is the nickname
+        raw = (restArg or ""):trim()
+        if raw == nil or raw == "" then
+            player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Usage: !givenickname <index> <nickname>")
+            return false
+        end
+    end
+
+    -- if summon exists but getUsingBall() didn't find (maybe isBeingUsed wasn't set),
+    -- try to find the correct ball inside the player's backpack by matching pokeName/level/boost/health
+    if summon and (not ball or not ball:isPokeball()) then
+        -- first try exact match via player storage (set by doReleaseSummon)
+        local lastUid = player:getStorageValue(95000)
+        if lastUid and lastUid > 0 then
+            local item = Item(lastUid)
+            if item and item:isPokeball() then
+                local owner = item:getSpecialAttribute("owner")
+                if not owner or owner == player:getName() then
+                    ball = item
+                end
+            end
+        end
+
+        local sName = summon:getSummonName() or summon:getName()
+        local sLevel = summon:getSummonLevel()
+        local sBoost = summon:getSummonBoost()
+        local sHealth = summon:getHealth()
+        local candidates = player:getPokeballs() or {}
+        local now = os.time()
+        local bestLast = 0
+        local bestBall = nil
+        local isBeingBall = nil
+        for i=1, #candidates do
+            local b = candidates[i]
+            if b and b:isPokeball() then
+                local bUid = tostring(b.uid)
+                local lastUsed = b:getSpecialAttribute("lastSummonAt")
+                local lastNum = tonumber(lastUsed) or 0
+                local isBeing = b:getSpecialAttribute("isBeingUsed")
+                local bName = b:getSpecialAttribute("pokeName")
+                local bLevel = b:getSpecialAttribute("pokeLevel")
+                local bBoost = b:getSpecialAttribute("pokeBoost")
+                local bHealth = b:getSpecialAttribute("pokeHealth")
+                -- debug: log candidate info (temporary)
+                print("give_nickname: candidate ball uid=", bUid, " lastSummonAt=", tostring(lastUsed), " isBeing=", tostring(isBeing), " name=", tostring(bName), " level=", tostring(bLevel), " boost=", tostring(bBoost), " health=", tostring(bHealth))
+                -- prefer the most recent lastSummonAt value
+                if lastNum > bestLast then
+                    bestLast = lastNum
+                    bestBall = b
+                end
+                if isBeing and isBeing == 1 then
+                    isBeingBall = b
+                end
+                -- fallback matching by pokeName/level/boost/health
+                if bName == sName and bLevel == sLevel and bBoost == sBoost then
+                    if bHealth == sHealth or not ball then
+                        ball = b
+                        if bHealth == sHealth then break end
+                    end
+                end
+            end
+        end
+        -- after scanning, prefer the most recently used ball if any
+        if bestBall then
+            print("give_nickname: choosing bestBall uid=", tostring(bestBall.uid), " bestLast=", tostring(bestLast))
+            ball = bestBall
+        elseif isBeingBall then
+            print("give_nickname: choosing isBeingBall uid=", tostring(isBeingBall.uid))
+            ball = isBeingBall
+        end
+    end
+
+    -- fallback to ammo slot or any using ball
+    if not ball or not ball:isPokeball() then
+        ball = player:getSlotItem(CONST_SLOT_AMMO) or ball
+    end
+
+    if not ball or not ball:isPokeball() then
+        print("give_nickname: no pokeball found for player=", tostring(player and player:getName()))
+        player:sendCancelMessage("No active pokeball found. Summon must be active or have the pokeball in backpack.")
+        return false
+    end
+
+    -- sanitize nickname: remove problematic characters that can break serialization
+    local function sanitizeNick(s)
+        if not s then return s end
+        -- trim and remove surrounding quotes
+        s = s:trim()
+        if (#s >= 2) then
+            local first = s:sub(1,1)
+            local last = s:sub(-1,-1)
+            if (first == '"' and last == '"') or (first == "'" and last == "'") then
+                s = s:sub(2, -2)
+            end
+        end
+        -- remove control chars, backslashes and quotes
+        s = s:gsub('[%c\\\"]', '')
+        -- collapse multiple spaces
+        s = s:gsub('%s+', ' ')
+        s = s:trim()
+        return s
+    end
+
+    local nickname = sanitizeNick(raw)
+
+    -- set the nickname on the active summon (if present) only if the server
+    -- has not locked the name. If the name is locked, persist to the pokeball(s)
+    -- and inform the player; the locked name is authoritative until changed by
+    -- a privileged operation or a future unsummon/resummon.
+    if summon and summon:isMonster() then
+        local locked = false
+        pcall(function() locked = summon:isNameLocked() end)
+        if not locked then
+            -- safe to rename the active summon
+            pcall(function() summon:setName(nickname) end)
+            player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Summon renamed to: " .. nickname)
+        else
+            -- name is locked by the server; persist nickname to ball(s) instead
+            player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Nickname saved to pokeball: " .. nickname .. " (current summon has a locked name)")
+            -- do NOT schedule a deferred rename: the server lock is authoritative
+            -- and deferred attempts may produce noisy prevented-overwrite logs. Persisting
+            -- to the pokeball(s) is sufficient; the name will change on next unsummon/resummon
+            -- or if unlocked by a privileged operation.
+        end
+    else
+        player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Nickname saved to pokeball: " .. nickname)
+    end
+
+    -- persist to pokeball so future summons inherit it
+    if nickname and nickname ~= "" then
+        -- write to the chosen ball
+        ball:setSpecialAttribute("pokeNickname", nickname)
+        -- also update the ball description so onLook shows the nickname immediately
+        if updatePokeballDescription then
+            pcall(function() updatePokeballDescription(ball) end)
+        end
+        -- Additionally, to avoid mismatches when multiple identical balls exist (different uids),
+        -- propagate the nickname to all matching pokeballs in the player's inventory.
+        local function propagateToMatchingBalls(targetBall, nick)
+            local pname = targetBall and targetBall:getSpecialAttribute("pokeName")
+            local plevel = targetBall and targetBall:getSpecialAttribute("pokeLevel")
+            local pboost = targetBall and targetBall:getSpecialAttribute("pokeBoost")
+            local owner = targetBall and targetBall:getSpecialAttribute("owner")
+            if not pname then return end
+            local candidates = player:getPokeballs() or {}
+            for i = 1, #candidates do
+                local b = candidates[i]
+                if b and b:isPokeball() then
+                    local bName = b:getSpecialAttribute("pokeName")
+                    local bLevel = b:getSpecialAttribute("pokeLevel")
+                    local bBoost = b:getSpecialAttribute("pokeBoost")
+                    local bOwner = b:getSpecialAttribute("owner")
+                    if bName == pname and bLevel == plevel and bBoost == pboost and (not bOwner or bOwner == owner or bOwner == player:getName()) then
+                        b:setSpecialAttribute("pokeNickname", nick)
+                        if updatePokeballDescription then
+                            pcall(function() updatePokeballDescription(b) end)
+                        end
+                        print("give_nickname: propagated nickname=", tostring(nick), " to ball uid=", tostring(b.uid))
+                    end
+                end
+            end
+            -- also try ammo slot if present and not already in list
+            local ammo = player:getSlotItem(CONST_SLOT_AMMO)
+            if ammo and ammo:isPokeball() then
+                local aName = ammo:getSpecialAttribute("pokeName")
+                local aLevel = ammo:getSpecialAttribute("pokeLevel")
+                local aBoost = ammo:getSpecialAttribute("pokeBoost")
+                local aOwner = ammo:getSpecialAttribute("owner")
+                if aName == pname and aLevel == plevel and aBoost == pboost and (not aOwner or aOwner == owner or aOwner == player:getName()) then
+                    ammo:setSpecialAttribute("pokeNickname", nick)
+                    if updatePokeballDescription then
+                        pcall(function() updatePokeballDescription(ammo) end)
+                    end
+                    print("give_nickname: propagated nickname to ammo slot uid=", tostring(ammo.uid))
+                end
+            end
+        end
+        propagateToMatchingBalls(ball, nickname)
+        print("give_nickname: saved nickname=", tostring(nickname), " to ball uid=", tostring(ball and ball.uid), " pokeName=", tostring(ball and ball:getSpecialAttribute("pokeName")))
+    else
+        ball:setSpecialAttribute("pokeNickname", nil)
+    end
+    -- update pokebar UI if you have one
+    if not player:isPlayer() then return true end
+    if player.refreshPokemonBar then
+        pcall(function() player:refreshPokemonBar({}, {}) end)
+    end
+
+    return true
+end
+
+-- utility: trim (if not present globally)
+if not string.trim then
+    function string.trim(s)
+        return (s:gsub("^%s*(.-)%s*$", "%1"))
+    end
+end

--- a/data/talkactions/scripts/spawn_with_nick.lua
+++ b/data/talkactions/scripts/spawn_with_nick.lua
@@ -1,0 +1,13 @@
+function onSay(player, words, param)
+    local pokeName = "Bellsprout"
+    local nickname = (param and param:trim() ~= "") and param:trim() or "pota"
+    local pos = player:getPosition()
+    -- Game.createMonster(name, position, extended?, force?, level, boost, skull, nature, initName)
+    local m = Game.createMonster(pokeName, pos, true, true, 0, 0, nil, nil, nickname)
+    if m then
+        player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Spawned: " .. m:getName() .. " (id=" .. m:getId() .. ")")
+    else
+        player:sendCancelMessage("Failed to spawn.")
+    end
+    return true
+end

--- a/data/talkactions/scripts/testnatures.lua
+++ b/data/talkactions/scripts/testnatures.lua
@@ -1,0 +1,5 @@
+function onSay(player, words, param)
+  dofile('data/tests/test_natures.lua')
+  runNatureTests(player)
+  return true
+end

--- a/data/talkactions/talkactions.xml
+++ b/data/talkactions/talkactions.xml
@@ -26,6 +26,8 @@
 	<talkaction words="/s" separator=" " script="place_npc.lua" />
 	<talkaction words="/addtutor" separator=" " script="add_tutor.lua" />
 	<talkaction words="/removetutor" separator=" " script="remove_tutor.lua" />
+	<talkaction words="/givenickname" separator=" " script="give_nickname.lua" />
+	<talkaction words="/ss" separator=" " script="spawn_with_nick.lua" />
 	<talkaction words="/looktype" separator=" " script="looktype.lua" />
 	<talkaction words="/summon" separator=" " script="place_summon.lua" />
 	<talkaction words="/chameleon" separator=" " script="chameleon.lua" />
@@ -35,6 +37,7 @@
 	<talkaction words="/save" script="save.lua" />
 	<talkaction words="/clean" script="clean.lua" />
 	<talkaction words="/hide" script="hide.lua" />
+	<talkaction words="/ts" script="testnatures.lua" />
 	<talkaction words="/setactionid" separator=" " script="set_actionid.lua" />
 	<talkaction words="/removeoutfit" separator=" " script="remove_outfit.lua" />
 	<talkaction words="/addpremium" separator=" " script="add_premium.lua" />

--- a/data/tests/test_natures.lua
+++ b/data/tests/test_natures.lua
@@ -1,0 +1,121 @@
+-- Test script: src/data/tests/test_natures.lua
+-- Usage: call runNatureTests(player) from a server-side environment (e.g. an in-game Lua executor or event handler)
+-- Spawns temporary creatures with each nature, prints their stats and annotations, then removes them.
+
+local natures = {
+	NATURE_ADAMANT, NATURE_BASHFUL, NATURE_BOLD, NATURE_BRAVE, NATURE_CALM,
+	NATURE_CAREFUL, NATURE_DOCILE, NATURE_GENTLE, NATURE_HARDY, NATURE_HASTY,
+	NATURE_IMPISH, NATURE_JOLLY, NATURE_LAX, NATURE_LONELY, NATURE_MILD,
+	NATURE_MODEST, NATURE_NAIVE, NATURE_NAUGHTY, NATURE_QUIET, NATURE_QUIRKY,
+	NATURE_RASH, NATURE_RELAXED, NATURE_SASSY, NATURE_SERIOUS, NATURE_TIMID,
+}
+
+function runNatureTests(player)
+	if not player or not player:isPlayer() then
+		print("runNatureTests: supply a Player object")
+		return false
+	end
+
+	local basePos = player:getPosition()
+	local offset = 1
+
+	-- try to require the nature_behaviors prototype so tests explicitly start thinker
+	local nature_behaviors = nil
+	cpcall = pcall
+	cpcall(function() nature_behaviors = require("lib/core/nature_behaviors") end)
+
+	for i, nat in ipairs(natures) do
+		-- capture nat into a local per-iteration variable to avoid closure-capture bugs
+		local localNat = nat
+		local testPos = {x = basePos.x + offset, y = basePos.y, z = basePos.z}
+		offset = offset + 1
+		local name = "Pidgey" -- choose a harmless summonable monster present on server; change if unavailable
+		
+		local natName = nil
+		if type(getNatureName) == "function" then
+			natName = getNatureName(nat)
+		else
+			natName = tostring(nat)
+		end
+		
+		local expectedNickname = "Test " .. natName
+		
+		-- createMonster(name, pos, force, isSummon, level, boost, skull, nature, initName)
+		local created = Game.createMonster(name, testPos, true, true, 1, 0, nil, nat, expectedNickname)
+		
+		if created then
+			local c = Creature(created)
+			if c and c:isMonster() then
+				local th = c:getTotalHealth()
+				local ta = c:getTotalMeleeAttack()
+				local tma = c:getTotalMagicAttack()
+				local td = c:getTotalDefense()
+				local tmd = c:getTotalMagicDefense()
+				local ts = c:getTotalSpeed()
+				
+				local currentName = c:getName()
+				local nickStatus = "OK"
+				
+				if currentName ~= expectedNickname then
+					-- Initial assignment failed (likely due to nature arg interference).
+					-- Try to force it manually.
+					pcall(function() c:setName(expectedNickname) end)
+					if c:getName() == expectedNickname then
+						nickStatus = "OK (Manual)"
+					else
+						nickStatus = "FAIL (Got: " .. c:getName() .. ", Expected: " .. expectedNickname .. ")"
+					end
+				end
+
+				local out = string.format("Nature: %s (%d) — Nick: %s — Health: %d, Atk: %d, MAtk: %d, Def: %d, MDef: %d, Spd: %d", natName, nat, nickStatus, th, ta, tma, td, tmd, ts)
+				-- send to player and server log
+				player:sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, out)
+				print(out)
+				
+				-- ensure behavior profile is applied (start thinker) even if spawn hook didn't run
+				if nature_behaviors and type(nature_behaviors.applyNatureBehavior) == "function" then
+					pcall(nature_behaviors.applyNatureBehavior, c)
+				end
+			else
+				player:sendTextMessage(MESSAGE_STATUS_WARNING, "Failed to create test monster for nature " .. tostring(nat))
+			end
+		else
+			player:sendTextMessage(MESSAGE_STATUS_WARNING, "Game.createMonster failed for nature " .. tostring(nat))
+		end
+		-- remove the creature after a short delay so stats are readable in-game
+		-- addEvent cannot accept userdata; pass a numeric creature id instead
+		local cid = nil
+		if created then
+			if type(created) == "number" then
+				cid = created
+			else
+				local tmp = Creature(created)
+				if tmp then cid = tmp:getId() end
+			end
+		end
+		if cid then
+			-- remove after 60 seconds (60000 ms)
+			addEvent(function(id)
+				local cc = Creature(id)
+				if cc then cc:remove() end
+			end, 60000, cid)
+
+			-- schedule applyNatureBehavior after a short delay so creature has a numeric id
+			addEvent(function(id)
+				pcall(function()
+					local ok, mod = pcall(require, 'lib/core/nature_behaviors')
+						if ok and mod and type(mod.applyNatureBehavior) == "function" then
+							local cc = Creature(id)
+							if cc then
+								pcall(function()
+									mod.applyNatureBehavior(cc)
+								end)
+								print(string.format("[test_natures] scheduled applyNatureBehavior for id=%d nat=%s", id, tostring(localNat)))
+							end
+					end
+				end)
+			end, 100, cid)
+		end
+	end
+	return true
+end

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -164,6 +164,21 @@ void Creature::setNatureAndLock(Natures_t newNature)
 	g_game.updateCreatureType(this);
 }
 
+void Creature::setNameAndLock(const std::string& name, const std::string& description)
+{
+	// Use the virtual setName implementation to apply the per-instance visible
+	// name/description, then mark the name as locked so C++ won't overwrite it.
+	setName(name, description);
+	nameLocked = true;
+	// Notify clients about the possible type/name change
+	g_game.updateCreatureType(this);
+}
+
+bool Creature::isNameLocked() const
+{
+	return nameLocked;
+}
+
 int64_t Creature::getTimeSinceLastMove() const
 {
 	if (lastStep) {

--- a/src/creature.h
+++ b/src/creature.h
@@ -177,6 +177,15 @@ class Creature : virtual public Thing
 		void setNature(Natures_t newNature);
 		// Atomically set the nature and lock it to prevent subsequent C++ overwrites.
 		void setNatureAndLock(Natures_t newNature);
+		// Atomically set a per-instance visible name/description and lock it to prevent
+		// subsequent C++ overwrites (mirrors skull/nature locking semantics).
+		void setNameAndLock(const std::string& name, const std::string& description = "");
+
+		// Allow scripts to set a per-instance visible name/description for a creature.
+		virtual void setName(const std::string& name, const std::string& description = "") {}
+
+		// Query whether the visible name was locked by the server (setNameAndLock).
+		bool isNameLocked() const;
 
 		// Locking: when locked, C++ code will avoid changing the skull to prevent
 		// overwrites of values explicitly set by scripts. Scripts call
@@ -554,6 +563,10 @@ class Creature : virtual public Thing
 
 		Natures_t nature = NATURE_NONE;
 		bool natureLocked = false;
+
+		// When true, C++ code will avoid changing the visible name as it was
+		// explicitly set by scripts/constructors and locked for this instance.
+		bool nameLocked = false;
 
 		bool localMapCache[mapWalkHeight][mapWalkWidth] = {{ false }};
 		bool isInternalRemoved = false;

--- a/src/docs/NATURES_SYSTEM.MD
+++ b/src/docs/NATURES_SYSTEM.MD
@@ -1,26 +1,283 @@
-Nature	Increases	Decreases
-Adamant	Attack	Magic Attack
-Bashful	Magic Attack	Magic Attack
-Bold	Defense	Attack
-Brave	Attack	Speed
-Calm	Magic Defense	Attack
-Careful	Magic Defense	Magic Attack
-Docile	Defense	Defense
-Gentle	Magic Defense	Defense
-Hardy	Attack	Attack
-Hasty	Speed	Defense
-Impish	Defense	Magic Attack
-Jolly	Speed	Magic Attack
-Lax	Defense	Magic Defense
-Lonely	Attack	Defense
-Mild	Magic Attack	Defense
-Modest	Magic Attack	Attack
-Naive	Speed	Magic Defense
-Naughty	Attack	Magic Defense
-Quiet	Magic Attack	Speed
-Quirky	Magic Defense	Magic Defense
-Rash	Magic Attack	Magic Defense
-Relaxed	Defense	Speed
-Sassy	Magic Defense	Speed
-Serious	Speed	Speed
-Timid	Speed	Attack
+Sistema de Natures (Personalidades)
+
+Este documento descreve o sistema de "Nature" (personalidade) implementado no servidor, quais arquivos foram alterados e os passos necessários para adicionar/alterar natures.
+
+## Visão geral
+
+Cada criatura (monstro/summon/pokémon) pode possuir uma Nature (personalidade). Cada Nature pode:
+
+- Aumentar um atributo em +10% (boost).
+- Reduzir um atributo em -10% (reduce).
+- Ser neutra (quando aumenta e reduz o mesmo atributo — nenhum efeito).
+
+As Natures são representadas por constantes `NATURE_*` (enum C++) e registradas no ambiente Lua. Quando um pokéball armazena uma criatura, seu valor numérico de Nature é persistido no atributo especial `pokeNature`. Em corpses usamos `corpseNature` para depuração/persistência.
+
+As estatísticas afetadas atualmente são: `attack`, `magicAttack`, `defense`, `magicDefense` e `speed`.
+
+## Tabela de natures
+
+Nature | Increases | Decreases
+---|---:|---:
+Adamant | Attack | Magic Attack
+Bashful | Magic Attack | Magic Attack (neutral)
+Bold | Defense | Attack
+Brave | Attack | Speed
+Calm | Magic Defense | Attack
+Careful | Magic Defense | Magic Attack
+Docile | Defense | Defense (neutral)
+Gentle | Magic Defense | Defense
+Hardy | Attack | Attack (neutral)
+Hasty | Speed | Defense
+Impish | Defense | Magic Attack
+Jolly | Speed | Magic Attack
+Lax | Defense | Magic Defense
+Lonely | Attack | Defense
+Mild | Magic Attack | Defense
+Modest | Magic Attack | Attack
+Naive | Speed | Magic Defense
+Naughty | Attack | Magic Defense
+Quiet | Magic Attack | Speed
+Quirky | Magic Defense | Magic Defense (neutral)
+Rash | Magic Attack | Magic Defense
+Relaxed | Defense | Speed
+Sassy | Magic Defense | Speed
+Serious | Speed | Speed (neutral)
+Timid | Speed | Attack
+
+## Como o sistema foi implementado (passo a passo)
+
+Resumo das alterações principais e onde procurar o código:
+
+1. Constantes / enum
+	- Arquivo: `src/const.h`
+	- Foi adicionada a enum `Natures_t` contendo as constantes `NATURE_*` (25 entradas). Estas constantes são usadas tanto em C++ quanto em Lua.
+
+2. Registro em Lua
+	- Arquivo: `src/luascript.cpp`
+	- Todas as constantes `NATURE_*` são registradas com `registerEnum(...)` para ficarem acessíveis nos scripts Lua.
+
+3. Extensão do parsing de monstros (opcional/definido por `MonsterType`)
+	- Arquivo: `src/monsters.cpp` / `src/monsters.h`
+	- `MonsterType::MonsterInfo` foi estendido para suportar uma natureza por defeito definida no XML do monstro e para listas/opções de `naturerandom` (quando aplicável).
+
+4. Passagem/armazenamento de nature ao criar monstros
+	- Arquivos: `src/monster.cpp`, `src/monster.h`, `src/game.cpp` (pontos de criação relevantes)
+	- `Monster::createMonster` e o construtor de `Monster` foram atualizados para aceitar um parâmetro `initNature`. A precedência de seleção da nature é: `MonsterType::info.nature` (defaut no XML) > `initNature` passado pela API > escolha ponderada/aleatória definida em `MonsterType` > `NATURE_NONE` para summons sem nature.
+	- Quando o parâmetro `initNature` for usado pelo código chamador, `setNatureAndLock` é aplicado para evitar que o C++ sobrescreva o valor logo em seguida.
+
+5. API de Creature (C++)
+	- Arquivos: `src/creature.h`, `src/creature.cpp`
+	- Adicionados membros `Natures_t nature`, `bool natureLocked`, e métodos `setNature` / `setNatureAndLock` (espelhando o modelo usado para skull/sex). `setNatureAndLock` faz lock para indicar que a value foi definida por inicialização e não deve ser sobrescrita por rotinas automáticas.
+
+6. Bindings Lua para Nature
+	- Arquivo: `src/luascript.cpp` (registrations) e `src/luascript.h` (declarações)
+	- `Creature:getNature()` e `Creature:setNature(nature)` foram expostos ao Lua; `setNature` usa `setNatureAndLock` para preservar o valor quando scripts definem nature manualmente.
+
+7. Persistência e scripts Lua
+	- Arquivos: vários scripts Lua em `src/data/...` (por exemplo, captura/liberação e corpse scripts)
+	- `pokeNature` foi adicionado como atributo especial no item pokéball quando uma criatura é capturada. Ao liberar o summon a partir da pokéball, o atributo `pokeNature` (se presente) é passado para `Game.createMonster` para que a summon mantenha a mesma natureza.
+	- `corpseNature` também foi gravado nos scripts de corpse para depuração e persistência intermediária.
+
+8. Mapeamentos e aplicação de modificadores (Lua)
+	- Arquivo: `src/data/lib/core/newfunctions.lua`
+	- Duas tabelas globais foram adicionadas: `natureBoost` e `natureReduce`, que mapeiam `NATURE_*` para a string do atributo afetado (por exemplo, "attack", "magicAttack", "defense", "magicDefense", "speed").
+	- A função utilitária `applyNatureModifier(total, statName, creature)` aplica a multiplicação correta:
+		 - se `boost == statName` e `reduce ~= statName`: floor(total * 1.10)
+		 - se `reduce == statName` e `boost ~= statName`: floor(total * 0.90)
+		 - se `boost == reduce == statName` (neutral): sem alteração
+	- Esta função é utilizada nas funções por-stat do monster (ex.: `Monster.getTotalMeleeAttack`, `Monster.getTotalMagicAttack`, `Monster.getTotalDefense`, `Monster.getTotalMagicDefense`, `Monster.getTotalSpeed`).
+
+9. Interface de apresentação (on-look)
+	- Arquivo: `src/data/events/scripts/player.lua`
+	- `Player:onLook` (e variações `onLookInTrade` / `onLookInBattleList`) foram atualizados para mostrar a Nature legível e, para summons, anotar visualmente os efeitos de boost/reduce: por exemplo "Attack: 55 (+10%)" e "Defense: 45 (-10%)". A implementação usa `natureBoost`/`natureReduce` para manter a UI sincronizada com a lógica.
+
+10. Limpeza e testes locais
+	 - Pequenos patches de correção de declarações (por exemplo, declarações faltantes em `src/luascript.h`) e correções de sintaxe em scripts Lua foram aplicadas para evitar erros de build/parse.
+
+## Como adicionar ou alterar uma Nature
+
+1. Adicione/edite uma entrada em `src/const.h` na enum `Natures_t` (mantendo o valor numérico consistente se necessário para persistência).
+2. Registre a constante em `src/luascript.cpp` com `registerEnum(NATURE_YOURNAME)` para exposição em scripts.
+3. Em `src/data/lib/core/newfunctions.lua` adicione/atualize `natureBoost[NATURE_YOURNAME] = "statName"` e `natureReduce[NATURE_YOURNAME] = "otherStatName"`. Use as strings: `"attack"`, `"magicAttack"`, `"defense"`, `"magicDefense"`, `"speed"`.
+4. (Opcional) Atualize a documentação (`src/docs/NATURES_SYSTEM.MD`) com a nova natureza e suas implicações.
+5. Compile, carregue o mundo e teste uma captura/liberação e `onLook` para verificar os efeitos numericamente e a anotação no cliente.
+
+## Persistência e atributos relevantes
+
+- `pokeNature` (item special attribute): armazenado na pokéball quando o summon é removido/recolhido; restaurado ao liberar a summon.
+- `corpseNature` (corpse special attribute): usado para log/debug de corpses (quando aplicável).
+- `setNatureAndLock` (C++): método usado quando um valor de nature foi definido no momento da criação para evitar sobrescrita.
+
+## Testes sugeridos
+
+1. Capturar um monstro normal, inspecionar a pokéball: verifique `pokeNature` gravado (pode usar logs/prints).  
+2. Liberar a summon com `doReleaseSummon`: verificar que a summon tem a mesma nature e que as estatísticas exibidas via `onLook` mostram "+10%" / "-10%" conforme a tabela de natures.  
+3. Testar natures neutras (ex.: Hardy, Bashful) e confirmar que as estatísticas não mudam.  
+4. Testar criaturas geradas por `Game.createMonster(..., initNature)` para confirmar que `setNatureAndLock` mantém a value fornecida.
+
+## Changelog (resumo das ações aplicadas)
+
+- Criado/estendido enum `Natures_t` e registradas constantes em Lua.  
+- Extenso suporte em C++ para transportar um parâmetro `initNature` na criação de monsters e lock de natureza.  
+- Adicionados métodos Lua `Creature:getNature()` e `Creature:setNature()` expostos e implementados para usar lock quando apropriado.  
+- Persistência em pokéballs (`pokeNature`) e corpses (`corpseNature`) adicionada.  
+- Mapeamentos `natureBoost` / `natureReduce` implementados em `newfunctions.lua` e a função `applyNatureModifier` aplicada nas funções de cálculo de status.  
+- `Player:onLook` e scripts relacionados atualizados para exibir a Nature e anotações (+10% / -10%).
+
+---
+
+Se quiser, eu posso:
+
+- Incluir exemplos de XML de monstros com `<nature>` / `<naturerandom>` para referência.  
+- Executar um build rápido e um conjunto de scripts de teste que gerem descrições `onLook` para um conjunto de natures (ex.: Adamant, Modest, Jolly) e postar o resultado aqui.
+
+Data da documentação: 15/11/2025
+
+
+
+COMPORTAMENTOS NATURES
+✅ 25 Natures → 25 Comportamentos de Criaturas
+Legenda rápida
+
+Hostile 1 / Passive 0 → Agressivo
+
+Hostile 1 / Passive 1 → Defensivo (só revida / recua com low HP)
+
+Hostile 0 / Passive 1 → Amedrontado / pacífico
+
+Hostile 0 / Passive 0 → Amistoso (segue o player mas não ataca)
+
+runonhealth: porcentagem em que foge
+
+staticattack: quão agitada é a IA (baixo = agitado; alto = parado)
+
+targetdistance: distância ideal do alvo
+
+⭐ 1. Hardy (Neutro)
+
+Criatura padrão, equilíbrio total.
+hostile=1 passive=1 runonhealth=20% staticattack=3000 targetdistance=1
+
+⭐ 2. Lonely (Ataque↑ Defesa↓)
+
+Bate forte mas tem medo de se machucar.
+hostile=1 passive=1 runonhealth=40% staticattack=2000 targetdistance=1
+
+⭐ 3. Brave (Ataque↑ Velocidade↓)
+
+Agressiva mas lenta e decidida.
+hostile=1 passive=0 runonhealth=0 staticattack=50000 targetdistance=1
+
+⭐ 4. Adamant (Ataque↑ Atq. Esp↓)
+
+Agressor corpo-a-corpo puro.
+hostile=1 passive=0 runonhealth=0 staticattack=1500 targetdistance=1
+
+⭐ 5. Naughty (Ataque↑ Def. Esp↓)
+
+Agressivo caótico, não pensa em recuar.
+hostile=1 passive=0 runonhealth=0 staticattack=800 targetdistance=2
+
+⭐ 6. Bold (Defesa↑ Ataque↓)
+
+Tank que evita atacar até ser provocado.
+hostile=1 passive=1 runonhealth=30% staticattack=7000 targetdistance=1
+
+⭐ 7. Docile (Neutro)
+
+Parecido com Hardy, mas menos agressivo.
+hostile=1 passive=1 runonhealth=25% staticattack=4000
+
+⭐ 8. Relaxed (Defesa↑ Velocidade↓)
+
+Lento e resistente, recua tarde.
+hostile=1 passive=1 runonhealth=15% staticattack=25000
+
+⭐ 9. Impish (Defesa↑ Atq. Esp↓)
+
+Defensor brincalhão — provoca mas não mata.
+hostile=1 passive=1 runonhealth=35% staticattack=3000
+
+⭐ 10. Lax (Defesa↑ Def. Esp↓)
+
+Briga mas foge cedo por ser descuidado.
+hostile=1 passive=1 runonhealth=50% staticattack=3500
+
+⭐ 11. Modest (Atq. Esp↑ Ataque↓)
+
+Mage que ataca de longe e evita contato.
+hostile=1 passive=1 targetdistance=5 runonhealth=30% staticattack=2500
+
+⭐ 12. Mild (Atq. Esp↑ Defesa↓)
+
+Glass cannon emocional: bate forte e foge rápido.
+hostile=1 passive=1 runonhealth=60% targetdistance=4
+
+⭐ 13. Quiet (Atq. Esp↑ Velocidade↓)
+
+Canhão mágico parado.
+hostile=1 passive=0 runonhealth=0 staticattack=45000 targetdistance=5
+
+⭐ 14. Rash (Atq. Esp↑ Def. Esp↓)
+
+Agressivo mágico imprudente.
+hostile=1 passive=0 runonhealth=5% staticattack=1200
+
+⭐ 15. Calm (Def. Esp↑ Ataque↓)
+
+Criatura pacífica que só revida.
+hostile=1 passive=1 runonhealth=40% staticattack=6000
+
+⭐ 16. Gentle (Def. Esp↑ Defesa↓)
+
+Fácil de assustar, recua muito cedo.
+hostile=0 passive=1 runonhealth=80% staticattack=9000
+
+⭐ 17. Sassy (Def. Esp↑ Velocidade↓)
+
+Lento, resistente, e provoca o jogador.
+hostile=1 passive=1 runonhealth=20% staticattack=8000
+
+⭐ 18. Careful (Def. Esp↑ Atq. Esp↓)
+
+Evita perigo e tenta sempre recuar.
+hostile=1 passive=1 runonhealth=50% staticattack=12000
+
+⭐ 19. Jolly (Velocidade↑ Ataque↓)
+
+Criatura hiperativa que corre ao redor do jogador.
+hostile=0 passive=0 staticattack=500 targetdistance=2
+
+⭐ 20. Hasty (Velocidade↑ Defesa↓)
+
+Ataca e recua freneticamente (hit and run).
+hostile=1 passive=1 runonhealth=50% staticattack=200
+
+⭐ 21. Timid (Velocidade↑ Ataque↓)
+
+Foge de tudo, quase impossível de prender.
+hostile=0 passive=1 runonhealth=100% staticattack=1000
+
+⭐ 22. Naive (Velocidade↑ Def. Esp↓)
+
+Corre muito mas toma decisões ruins.
+hostile=1 passive=1 runonhealth=35% staticattack=900
+
+⭐ 23. Serious (Neutro)
+
+Comportamento consistente e previsível.
+hostile=1 passive=1 runonhealth=20% staticattack=3000
+
+⭐ 24. Bashful (Neutro tímido)
+
+Evita conflito até ser realmente atacado.
+hostile=1 passive=1 runonhealth=40% staticattack=4000
+
+⭐ 25. Quirky (Neutro imprevisível)
+
+Se comporta aleatoriamente entre agressivo/defensivo/amedrontado.
+hostile=1 passive=0/1 alternando
+runonhealth variável (0–60%)
+staticattack variável (500–8000)
+
+Ideal para criaturas “caóticas”.

--- a/src/docs/NICKNAME_PERSISTENCE_DEBUG.md
+++ b/src/docs/NICKNAME_PERSISTENCE_DEBUG.md
@@ -1,0 +1,138 @@
+# Nickname persistence — debugging notes
+
+Date: 2025-11-21
+Repository path: src/data/lib/core/newfunctions.lua, src/data/talkactions/scripts/give_nickname.lua, src/monster.cpp, src/creature.cpp, src/luascript.cpp
+
+## Problem summary (Português)
+
+O problema: nicknames dados por `!givenickname` são aplicados corretamente ao summon e persistem na pokeball após captura, mas ao recolher / re-summonar às vezes o pokémon aparece sem o nickname — como se o `pokeNickname` não tivesse sido persistido ou a pokeball correta não tivesse sido escolhida no recall.
+
+Logs de sessão (trecho):
+
+```
+GOD Pota has logged in.
+WARNING! Pokedex successfully built.
+give_nickname: propagated nickname=	pota	 to ball uid=	65536
+give_nickname: saved nickname=	pota	 to ball uid=	65536	 pokeName=	Bellsprout
+doReleaseSummon: using ball uid=	65537	 pokeName=	Bellsprout	 pokeNickname=	pota
+[Creature::setNatureAndLock] creature id=0 nature 0 -> 5
+doReleaseSummon: using ball uid=	65539	 pokeName=	Bellsprout	 pokeNickname=	Bellsprout
+[Creature::setNatureAndLock] creature id=0 nature 0 -> 5
+wgive_nickname: propagated nickname=	pota	 to ball uid=	65541
+give_nickname: saved nickname=	pota	 to ball uid=	65541	 pokeName=	Bellsprout
+doReleaseSummon: using ball uid=	65542	 pokeName=	Bellsprout	 pokeNickname=	pota
+[Creature::setNatureAndLock] creature id=0 nature 0 -> 5
+doReleaseSummon: using ball uid=	65544	 pokeName=	Bellsprout	 pokeNickname=	Bellsprout
+[Creature::setNatureAndLock] creature id=0 nature 0 -> 5
+```
+
+Observação: repara-se que o `give_nickname` salvou `pota` em UID 65536 e 65541, mas `doReleaseSummon` está usando outras UIDs (65537, 65539, 65542, 65544) para criar summons — parte deles têm `pokeNickname = pota`, outros não.
+
+## Reproduzir (passos sugeridos)
+
+1. Iniciar servidor com as mudanças atuais.
+2. Como GOD, spawnar um `Bellsprout` com nickname, ou usar `!givenickname pota` em uma pokeball existente.
+3. Checar que o summon aparece com o nick.
+4. Capturar o summon (fluxo de captura atual já grava `corpseNickname` -> `doAddPokeball` parameter -> `addBall:setSpecialAttribute("pokeNickname", safeNick)`).
+5. Conferir o atributo `pokeNickname` na pokeball (onLook deve também mostrar `Nickname: pota`).
+6. Re-summonar e imediatamente recolher; observar o log `doReleaseSummon: using ball uid= ... pokeNickname= ...` e verificar se a UID corresponde à mesma pokeball que recebeu o `pokeNickname` na captura. Repetir várias vezes com múltiplas balls idênticas.
+
+## Código e pontos relevantes (onde procurar)
+
+- Lua (summon/release/recall pipeline):
+  - `src/data/lib/core/newfunctions.lua`
+    - doReleaseSummon (lê `ball:getSpecialAttribute("pokeNickname")` e chama `Game.createMonster(..., storedNickname)`)
+    - doRemoveSummon (persistência em recall: grava `ball:setSpecialAttribute("pokeNickname", sname)`)
+    - doAddPokeball (quando captura: grava `addBall:setSpecialAttribute("pokeNickname", safeNick)` quando `corpseNickname` existe)
+    - sanitizeNickname / updatePokeballDescription
+  - `src/data/talkactions/scripts/give_nickname.lua`
+    - persiste `pokeNickname` com `ball:setSpecialAttribute("pokeNickname", nickname)` e propaga para matching balls
+
+- C++ (nome atômico / lock):
+  - `src/creature.h/cpp` - `Creature::setNameAndLock`, `Creature::isNameLocked()`
+  - `src/monster.h/cpp` - `Monster::createMonster(..., initName)` e `Monster` constructor chamando `setNameAndLock(initName)`
+  - `src/luascript.cpp` - binding `luaGameCreateMonster` foi alterado para aceitar o `initName` e passar ao `Monster::createMonster`.
+
+## Alterações já aplicadas (resumo)
+
+- `!givenickname`:
+  - sanitizer, propagation to matching pokeballs
+  - removed deferred rename attempts when the summon has `isNameLocked()` to avoid noisy C++ backtraces
+
+- `newfunctions.lua`:
+  - Summon creation now passes stored nickname into `Game.createMonster(..., initName)` so the C++ constructor applies + locks the name atomically.
+  - On successful creation we now store the originating ball UID on the monster with `monster:setStorageValue(95001, ball.uid)`.
+  - On remove/recall we first try to find the origin ball by reading `summon:getStorageValue(95001)` and using that Item instance if present; fallback to previous heuristics if not found.
+  - Deferred helpers that call `setName` were guarded by `isNameLocked()` to avoid overwrite attempts.
+
+## Hipóteses (por que ainda ocorre)
+
+1. Origin UID is not being stored or not persisted for some summons:
+   - `monster:setStorageValue(95001, ball.uid)` may fail silently in some flows (pcall used), or the `ball` value at moment of creation isn't the correct one.
+   - Race condition: `doReleaseSummon` might be using a different `ball` object (player:getUsingBall() or other heuristics) than the one that the player expects. If `ball` is changed between the time nickname is saved and summon creation, the stored origin UID can be incorrect.
+
+2. Multiple identical pokeballs + propagation inconsistencies:
+   - `give_nickname` propagates the nickname to matching pokeballs, but propagation depends on matching attributes (pokeName, level, boost, owner). If those attributes differ or are missing on some items, a subset of balls will have the nickname while the one chosen at release will not.
+
+3. Capture path vs give_nickname path:
+   - Capturing writes `pokeNickname` during `doAddPokeball` (from `corpseNickname` param). `!givenickname` writes with `ball:setSpecialAttribute("pokeNickname", nickname)` on the chosen ball. If these two write flows target different item instances (e.g., the ball returned to backpack is a different UID), the visible data will vary.
+
+4. Storage vs temporary data:
+   - There are multiple ephemeral markers: `isBeingUsed`, `lastSummonAt`, player storage 95000, monster storage 95001. Any of these might be set/cleared at unexpected times.
+
+## Suggested next diagnostics (high priority)
+
+1. Add deterministic debug traces (temporary) around these points and include the `ball.uid` and table identity where possible:
+   - Right before `monster:setStorageValue(95001, ball.uid)` in `doReleaseSummon`.
+   - Right before the `ball:setSpecialAttribute("pokeNickname", sname)` in `doRemoveSummon` (recall) to log which ball instance is being written.
+   - When `doAddPokeball` adds a ball (capture), log the UID of the created `addBall` and any `corpseNickname` it received.
+   - In `give_nickname`, log the chosen `ball.uid` and list all balls that were updated during propagation.
+
+2. Confirm that `monster:setStorageValue` persists across the monster lifetime (some TFS builds treat monster/player storages differently). If monsters do not support storage as expected, consider storing `originUid` in a lightweight map in Lua keyed by `monster:getId()` (and clean up on monster death/remove).
+
+3. Re-run the reproduce steps with the extra logging and capture the full sequence of events (spawn -> give_nickname -> capture -> doAddPokeball -> use/release -> doReleaseSummon -> doRemoveSummon). Compare the UIDs at each step.
+
+4. If origin UID is absent or wrong in some cases, inspect the logic that picks `ball` in `doReleaseSummon` — player:getUsingBall() vs heuristics. Consider making the selection deterministic by preferring `player:getSlotItem(CONST_SLOT_AMMO)` if present and matching expected attributes, or require players to place the ball in the ammo slot before summoning for testing.
+
+## Suggested code fixes (ranked)
+
+1. (Defensive) If monster storages are unreliable, maintain a Lua table mapping `monster:getId()` -> origin UID when you call `player:addSummon(monster)` and use that mapping in `doRemoveSummon` as the first preference. Remember to clear mapping when summon is removed.
+
+2. (Robust) Ensure `monster:setStorageValue(95001, ball.uid)` is executed unconditionally (avoid silent pcall swallowing actual errors) — log failure if it returns false.
+
+3. (Deterministic) On `doReleaseSummon`, pass the `ball.uid` into `Game.createMonster` as an additional optional parameter (not currently supported), or record as suggested (monster storage). This ties the created monster to the origin item deterministically.
+
+4. (Propagation) Improve `give_nickname` propagation heuristics to include item location (ammo/backpack slot), and optionally push nickname to all identical balls by item template UID rather than only matching attributes.
+
+5. (Cleanup) Remove debug prints when fixed; tighten use of `pcall` so errors don't silently hide problems.
+
+## Minimal test plan
+
+- Unit manual test: create 3 identical pokeballs for a player, name only one with `!givenickname`, spawn and recall repeatedly; expect the recalled ball to be the same UID the summon came from and keep the nickname.
+- Acceptance: no occurrences of mismatch for UID or missing `pokeNickname` in 20 repeated cycles across random picks.
+
+## Commands (build / run)
+
+```bash
+cd /path/to/src
+make -j$(nproc)
+# restart server (adjust to your run method)
+pkill -f tfs || true
+./tfs
+```
+
+## Checklist for the next developer/agent
+
+- [ ] Add temporary logs around origin UID store and recall write.
+- [ ] Reproduce and paste full chronological logs (spawn -> give_nickname -> capture -> addBall UID -> release -> removeSummon using ball UID -> recall write). Include timestamps to correlate.
+- [ ] If monster storage appears unreliable, implement in-Lua mapping fallback keyed by `monster:getId()`.
+- [ ] After fix, remove temporary logs and debug prints.
+
+---
+
+If precisar, posso aplicar as mudanças de debug (log prints) e rodar uma sessão de testes automáticos aqui no workspace. Diga se quer que eu:
+
+- A: adicione logs e rode a build/testes e cole os resultados aqui, ou
+- B: você mesmo aplica os passos de teste e me envia os logs para eu analisar.
+
+

--- a/src/docs/NICKNAME_SYSTEM.MD
+++ b/src/docs/NICKNAME_SYSTEM.MD
@@ -1,0 +1,106 @@
+# Nickname System — documentação de implementação
+
+Última atualização: 21/11/2025
+
+Este documento descreve o sistema de "Nickname" (apelidos) implementado no servidor, detalhando as alterações realizadas e o fluxo de dados para garantir a persistência correta dos nomes.
+
+## Visão geral
+
+O `Nickname System` permite que jogadores atribuam nomes personalizados aos seus summons. O sistema garante:
+
+- Atribuição de apelidos via comando `!givenickname`.
+- Persistência do apelido no item (pokéball) através do atributo especial `pokeNickname`.
+- Restauração do apelido ao evocar o summon (release), aplicando o nome no momento da criação.
+- Preservação do apelido ao recolher o summon (recall), evitando sobrescrita acidental pelo nome padrão.
+
+Para garantir a robustez, o sistema utiliza um mecanismo de "lock" semelhante aos sistemas de Gender e Nature, impedindo que o nome seja alterado indevidamente após a criação.
+
+---
+
+## Fluxo de dados (end-to-end)
+
+1. **Definição (`!givenickname`)**
+    - O jogador usa o comando `!givenickname <nome>`.
+    - O script `give_nickname.lua` sanitiza o nome e o aplica:
+        - Ao **summon ativo** (se houver e o nome não estiver travado).
+        - À **pokéball** correspondente (atributo `pokeNickname`).
+
+2. **Pokéball -> Summon (Release)**
+    - Ao liberar (`doReleaseSummon`), o script lê `storedNickname = ball:getSpecialAttribute("pokeNickname")`.
+    - O valor é passado para `Game.createMonster(..., storedNickname)`.
+    - O construtor do `Monster` (C++) recebe `initName` e chama `setNameAndLock(initName)`, aplicando o nome e travando-o (`nameLocked = true`).
+
+3. **Summon -> Pokéball (Recall)**
+    - Ao recolher (`doRemoveSummon`), o script verifica o nome atual do summon.
+    - **Lógica de Proteção**: O script compara o nome do summon com o nome padrão da espécie (`monsterType:getName()`).
+    - O atributo `pokeNickname` na pokéball só é atualizado se o nome do summon for **diferente** do padrão. Isso evita que um summon cujo nome não pôde ser alterado (ex: travado) sobrescreva um apelido válido na pokéball com o nome padrão.
+
+4. **Persistência em Captura**
+    - Ao capturar um monstro (`doAddPokeball`), se o corpo tiver um `corpseNickname` (ou se for um monstro selvagem sem nick), o atributo é salvo na nova pokéball.
+
+---
+
+## Como o sistema foi implementado (passo a passo)
+
+### 1. Alterações em C++
+
+- **`src/monster.h` / `src/monster.cpp`**
+    - `Monster::createMonster` e o construtor foram atualizados para aceitar um parâmetro opcional `const std::string& initName`.
+    - Se `initName` for fornecido, o construtor chama `setNameAndLock(initName)`.
+
+- **`src/creature.h` / `src/creature.cpp`**
+    - Adicionado método `setNameAndLock(name)`: define o nome e seta a flag `nameLocked = true`.
+    - Adicionado método `isNameLocked()`: retorna o estado da flag.
+    - `Creature::setName` respeita o lock, impedindo alterações se `nameLocked` for verdadeiro (exceto se for o mesmo nome).
+
+- **`src/luascript.cpp`**
+    - `luaGameCreateMonster` foi atualizado para ler o 9º argumento (string) e passá-lo como `initName` para o C++.
+
+### 2. Alterações em Lua
+
+- **`src/data/lib/core/newfunctions.lua`**
+    - **`doReleaseSummon`**:
+        - Lê `pokeNickname` da pokéball.
+        - Passa o nickname como último argumento para `Game.createMonster`.
+        - Persiste o UID da pokéball de origem no summon (`monster:setStorageValue(95001, ball.uid)`) para garantir o vínculo correto no recall.
+    - **`doRemoveSummon`**:
+        - Recupera a pokéball correta usando o UID armazenado (storage 95001) ou fallback para `getUsingBall`.
+        - Verifica se o nome do summon difere do padrão (`summon:getType():getName()`).
+        - Atualiza `pokeNickname` na pokéball apenas se houver um apelido válido e diferente do padrão.
+
+- **`src/data/talkactions/scripts/give_nickname.lua`**
+    - Implementa a lógica de comando.
+    - Tenta renomear o summon ativo. Se falhar (nome travado), avisa o jogador e salva apenas na pokéball.
+    - Propaga o apelido para pokéballs correspondentes no inventário.
+
+---
+
+## Persistência e Atributos
+
+- **`pokeNickname`** (Item Attribute): Armazena a string do apelido na pokéball.
+- **`nameLocked`** (Creature Flag): Indica que o nome foi definido na criação e não deve ser alterado por rotinas comuns.
+
+---
+
+## Testes Sugeridos
+
+1.  **Fluxo Básico**:
+    - Invocar monstro -> `!givenickname Teste` -> Recolher -> Invocar novamente.
+    - Verificar se o nome "Teste" persiste.
+
+2.  **Persistência no Recall**:
+    - Ter um monstro com apelido "Teste".
+    - Forçar uma situação onde o summon não tem o nome (ex: via script de debug ou falha simulada).
+    - Recolher o monstro.
+    - Verificar se a pokéball **mantém** "Teste" e não foi sobrescrita por "Bellsprout".
+
+3.  **Múltiplas Pokéballs**:
+    - Ter 3 Bellsprouts idênticos.
+    - Dar apelido a um deles.
+    - Garantir que apenas a pokéball correta recebe/mantém o apelido ao invocar e recolher.
+
+---
+
+## Observações
+
+O sistema segue estritamente o padrão estabelecido pelos sistemas de **Gender** e **Nature**, garantindo consistência na base de código e facilitando a manutenção. A correção crítica no `doRemoveSummon` (verificação de nome padrão e scoping de variável) foi essencial para resolver problemas de desaparecimento de nicks.

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -757,6 +757,9 @@ class LuaScriptInterface
 
 		static int luaCreatureGetId(lua_State* L);
 		static int luaCreatureGetName(lua_State* L);
+		static int luaCreatureGetNickname(lua_State* L);
+		static int luaCreatureSetName(lua_State* L);
+		static int luaCreatureIsNameLocked(lua_State* L);
 
 		static int luaCreatureGetTarget(lua_State* L);
 		static int luaCreatureSetTarget(lua_State* L);


### PR DESCRIPTION
This pull request introduces two major features: a prototype system for mapping Pokémon "natures" to AI behavior profiles, and improved support for Pokémon nicknames throughout catching, summoning, and UI display. The changes include a new `nature_behaviors` module, AI hooks for monsters, persistent nickname handling, and improvements to how Pokéballs and monsters are matched and described.

**Nature-based AI behaviors:**

* Added new module `data/lib/core/nature_behaviors.lua` that defines behavior profiles for each Pokémon nature and applies them to monsters via a Lua-side instance map. This includes periodic "thinkers" to enforce behaviors such as hostility, passivity, and fleeing at low health.
* Modified `data/events/scripts/monster.lua` to lazily require the new module, apply nature behavior profiles on spawn, and enforce them during `onThink`. Includes debug logging and fallback periodic thinkers for robustness. [[1]](diffhunk://#diff-ee7bc024cddbab55d497c3c755e11d97134cfa47e800b1ca3af416a7a3ee4caeR5-R8) [[2]](diffhunk://#diff-ee7bc024cddbab55d497c3c755e11d97134cfa47e800b1ca3af416a7a3ee4caeR347-R474)

**Pokémon nickname support:**

* Enhanced the corpse creation and catching process to persist a Pokémon's nickname, sanitize it, and store it in the Pokéball. The nickname is carried through all relevant function calls and is now passed to `Game.createMonster` for summoning. [[1]](diffhunk://#diff-5bfc67ff38b304eb3f7f4f430e3049425b7a5138999eaed775fb935f20d2d9efR22-R35) [[2]](diffhunk://#diff-c09f0df9103218b24da86eef0778a27bf79e958f569d1f036c997df3e3d3c796R86) [[3]](diffhunk://#diff-c09f0df9103218b24da86eef0778a27bf79e958f569d1f036c997df3e3d3c796L96-R99) [[4]](diffhunk://#diff-c6c7c867e448c6b77b793f9a0836c2832222ec64afd284664fb61ba716bee6b6R2477-R2498)
* Improved `doReleaseSummon` to log, sanitize, and pass nicknames, as well as persist the Pokéball UID on the summoned monster for precise matching on recall. [[1]](diffhunk://#diff-c6c7c867e448c6b77b793f9a0836c2832222ec64afd284664fb61ba716bee6b6R2422-R2429) [[2]](diffhunk://#diff-c6c7c867e448c6b77b793f9a0836c2832222ec64afd284664fb61ba716bee6b6R2477-R2498) [[3]](diffhunk://#diff-c6c7c867e448c6b77b793f9a0836c2832222ec64afd284664fb61ba716bee6b6R2510-R2515)
* Updated `doRemoveSummon` to prefer the originating Pokéball by UID when returning a monster, reducing mismatches with identical balls.

**User interface and display improvements:**

* Modified `Player:onLook` to display a Pokémon's nickname if it differs from the base name, both for summons and Pokéballs. [[1]](diffhunk://#diff-2d57af43e75e42cd5044e99416268d3fe6818693d746dc094994af181b26e1b5R121-R127) [[2]](diffhunk://#diff-2d57af43e75e42cd5044e99416268d3fe6818693d746dc094994af181b26e1b5R178-R182)

These changes lay the groundwork for more nuanced AI and a better player experience with personalized Pokémon.

---

**Nature-based AI system:**
- Added `nature_behaviors.lua` for mapping natures to AI behavior profiles and enforcing them via periodic thinkers.
- Integrated nature behavior application and enforcement on monster spawn and think events, with debug output for diagnostics. [[1]](diffhunk://#diff-ee7bc024cddbab55d497c3c755e11d97134cfa47e800b1ca3af416a7a3ee4caeR5-R8) [[2]](diffhunk://#diff-ee7bc024cddbab55d497c3c755e11d97134cfa47e800b1ca3af416a7a3ee4caeR347-R474)

**Nickname persistence and handling:**
- Persisted Pokémon nicknames from corpse to Pokéball, sanitized input, and ensured the nickname is passed to summoning functions. [[1]](diffhunk://#diff-5bfc67ff38b304eb3f7f4f430e3049425b7a5138999eaed775fb935f20d2d9efR22-R35) [[2]](diffhunk://#diff-c09f0df9103218b24da86eef0778a27bf79e958f569d1f036c997df3e3d3c796R86) [[3]](diffhunk://#diff-c09f0df9103218b24da86eef0778a27bf79e958f569d1f036c997df3e3d3c796L96-R99) [[4]](diffhunk://#diff-c6c7c867e448c6b77b793f9a0836c2832222ec64afd284664fb61ba716bee6b6R2477-R2498)
- During summoning, stored the Pokéball UID on the monster for reliable matching on recall, and deferred nickname setting as a safety. [[1]](diffhunk://#diff-c6c7c867e448c6b77b793f9a0836c2832222ec64afd284664fb61ba716bee6b6R2422-R2429) [[2]](diffhunk://#diff-c6c7c867e448c6b77b793f9a0836c2832222ec64afd284664fb61ba716bee6b6R2477-R2498) [[3]](diffhunk://#diff-c6c7c867e448c6b77b793f9a0836c2832222ec64afd284664fb61ba716bee6b6R2510-R2515)
- On recall, preferred the originating Pokéball by UID to avoid mismatches.

**UI improvements:**
- Displayed nicknames in the `onLook` description for both active summons and Pokéballs if a nickname is present and differs from the base name. [[1]](diffhunk://#diff-2d57af43e75e42cd5044e99416268d3fe6818693d746dc094994af181b26e1b5R121-R127) [[2]](diffhunk://#diff-2d57af43e75e42cd5044e99416268d3fe6818693d746dc094994af181b26e1b5R178-R182)